### PR TITLE
Mutables Back in Global Scope

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -16,9 +16,13 @@ typedef enum {
 // Local Variable operations
   OP_GET_LOCAL,
   OP_SET_LOCAL,
-// Global Variables get-global-op
-  OP_GET_GLOBAL,
+// Mutable Variables
+  OP_DEFINE_MUTABLE,
+  OP_SET_MUTABLE,
+  OP_GET_MUTABLE,
+// Global Constants get-global-op
   OP_DEFINE_GLOBAL,
+  OP_GET_GLOBAL,
   OP_SET_GLOBAL,
 // Closures operations
   OP_GET_UPVALUE,
@@ -34,6 +38,7 @@ typedef enum {
   OP_DIVIDE,
   OP_MODULO,
   OP_CONCATENATE, // TODO implement
+// MU_CONCATENATE,
 // Types of Values unary-ops
   OP_NOT,
   OP_NEGATE,

--- a/code.txt
+++ b/code.txt
@@ -1,28 +1,50 @@
 print "===Mu sample start===";
 
-let #simon : "Simon says!";
-print #simon;
-
-#simon := "Simon says stop!";
-print #simon;
-
-//let asdf;  // error, uninitialized constant
-let #mystery;
-print #mystery; // uninitialized is null, may also enforce initializing in the future
-
-print -5;       // unary negation
-
-print 0 - 5;    // subtraction
-print 5 - 6;    // subtraction
-#mystery := "The mystery is over"; // reassignment
-print #mystery;
-
 print " --Constant assignment";
 let phrase : "Hello World.";
 print phrase;
 
 // let phrase : "Nice to meet you."; // error cannot reassign constant
 // print phrase;
+
+print " --Mutable assignment";
+
+let #mystery : null; // even mutables need to be initialized
+print #mystery; 
+#mystery := "The mystery is over"; // reassignment
+print #mystery;
+
+print " --Arithmetic";
+print -5;       
+print 5 - 6;
+print 6 - 5;    
+print 3 + 14;
+print 12 * 12;
+print 60 / 25;
+print 5 % 4;
+
+print " --Compound Addition";
+let #test : 0;
+#test += 2;
+print #test; 
+#test := -15;
+#test += 10;
+print #test;
+print " --Compound Multiplication";
+#test := 2;
+#test *= 5;
+print #test;
+print " --Compound Division";
+#test /= 3;
+print #test;
+#test := 7;
+print " --Compound Modulo";
+#test %= 3;
+print #test;
+print " --Compound Concatenation";
+let #text : "one, two, three, ";
+#text .= "four, ";
+print #text;
 
 print " --And, Or";
 print 1 or 2;
@@ -36,12 +58,6 @@ print !(2 < 5);
 print !(3 = 2 + 1);
 print !(3 > 3 * 2);
 print !(2 = 1);
-
-print " --Modulo";
-let #id : 12;
-#id %= 5;
-print #id;
-print #id * 3;
 
 print " --While Loop";
 let #count : 1;
@@ -105,6 +121,10 @@ let last: " poe";
 let full_name: name .. last;
 print full_name;
 
+print " --Number Concatenation";
+let appended : 1 .. 5;
+print appended;
+
 print " --functions";
 
 let addTogether:
@@ -139,14 +159,14 @@ print fibonacci(20);
 
 print "--Global Scope";
 //  ** Mutables are not in global scope **
-//      let #number := 6;
-//      
-//      let increaseNumberBy: use x as
-//          #number := #number + x; // function doesn't know what #number is
-//          print #number;
-//      ,,
-//      increaseNumberBy(7); // won't work
-//
+      let #number : 6;
+      
+      let increaseNumberByFail: use x as
+          #number := #number + x; // function doesn't know what #number is
+          print #number;
+      ,,
+      increaseNumberByFail(7); // won't work
+
 //  ** Constants are in global scope **
 
 let number : 6;
@@ -207,26 +227,6 @@ let countTo: use x as
 
 countTo(4);
 
-let getSumOf : use x, y as 
-    return x + y; 
-,,
-
-print getSumOf(2, 5);
-
-let getProductOf : 
-    use x, y return x * y; 
-,, 
-print getProductOf(4, 3);
-
-let magicNumber : 12;
-
-let triplePlusValue : use y as
-  let #z : y;
-  #z *= 3;
-  return #z + magicNumber; 
-,,
-print triplePlusValue(9); // 39
-
 print " --Mutable Function Parameters";
 
 let test : use x, #y as
@@ -234,5 +234,15 @@ let test : use x, #y as
     return x + #y;
 ,,
 print test(1, 2);
+
+let #xyz : 15;
+#xyz *= 1.2;
+print #xyz;
+
+let moduloThis: use a, z as
+    return a % z;
+,,
+
+print moduloThis(19, 6);
 
 print "===Mu sample end ===";

--- a/common.h
+++ b/common.h
@@ -19,6 +19,7 @@
 // Local Variables
 #define UINT8_COUNT (UINT8_MAX + 1)
 
+
 #endif
 #undef DEBUG_PRINT_CODE
 #undef DEBUG_TRACE_EXECUTION

--- a/scanner.c
+++ b/scanner.c
@@ -185,9 +185,8 @@ static Token identifier() {
 static Token number() {
   while (isDigit(peek())) advance();
 
-  // Look for a fractional part.
-  if (peek() == '.' && isDigit(peekNext())) {
-    advance(); // Consume the "."
+  if (peek() == '.' && isDigit(peekNext())) { // Look for a fractional part.
+    advance(); // Consume "."
 
     while (isDigit(peek())) advance();
   }
@@ -195,7 +194,7 @@ static Token number() {
 }
 
 static Token string() {
-  while (peek() != '"' && !isAtEnd()) { // TODO use similar logic if implementing meaningufl new lines
+  while (peek() != '"' && !isAtEnd()) {
     if (peek() == '\n') scanner.line++;
     advance();
   }
@@ -222,15 +221,13 @@ Token scanToken() {
     case '#': return identifier();
     case '(': return makeToken(S_LEFT_PARENTHESES); // TODO would be new line aware
     case ')': return makeToken(S_RIGHT_PARENTHESES);
-    case '{': return makeToken(S_LEFT_CURLY); // TODO would be new line aware
+    case '{': return makeToken(S_LEFT_CURLY);   // TODO would be new line aware
     case '}': return makeToken(S_RIGHT_CURLY);
-    case '?': return makeToken(S_QUESTION); // TODO would be new line aware
+    case '?': return makeToken(S_QUESTION);     // TODO would be new line aware
     case ';': return makeToken(S_SEMICOLON);
-    case '=': return makeToken(S_EQUAL); //TOKEN_EQUAL_EQUAL
+    case '=': return makeToken(S_EQUAL); 
     case '-': return makeToken(S_MINUS);
     // two characters
-    case ',': 
-      return makeToken(match(',') ? D_COMMA : S_COMMA);
     case '.': 
       switch(scanner.start[1]) {
         case '=': advance();
@@ -241,23 +238,24 @@ Token scanToken() {
           return makeToken(S_DOT);
       }
       break;
-      //return makeToken(match('=') ? D_DOT_EQUAL : S_DOT);
+    case ',': 
+      return makeToken(match(',') ? D_COMMA : S_COMMA);
+    case '%': 
+      return makeToken(match('=') ? D_MODULO_EQUAL : S_MODULO);
     case '+': 
       return makeToken(match('=') ? D_PLUS_EQUAL : S_PLUS);
     case '/': 
       return makeToken(match('=') ? D_SLASH_EQUAL : S_SLASH);
     case '*': 
       return makeToken(match('=') ? D_STAR_EQUAL : S_STAR);
-    case '%': 
-      return makeToken(match('=') ? D_MODULO_EQUAL : S_MODULO);
     case ':': 
-      return makeToken(match('=') ? D_COLON_EQUAL: S_COLON); // TODO would be new line aware
-    case '!':
-      return makeToken(match('~') ? D_BANG_TILDE : S_BANG);
+      return makeToken(match('=') ? D_COLON_EQUAL: S_COLON);
     case '<':
       return makeToken(match('=') ? D_LESS_EQUAL : S_LESS);
     case '>':
       return makeToken(match('=') ? D_GREATER_EQUAL : S_GREATER);
+    case '!':
+      return makeToken(match('~') ? D_BANG_TILDE : S_BANG);
     case '"': return string();
   }
   return errorToken("Unexpected character.");

--- a/scanner.h
+++ b/scanner.h
@@ -12,27 +12,25 @@ typedef enum {
   // Two character tokens
   D_COMMA, D_BANG_TILDE, D_COLON_EQUAL,     // ,, !~ :=
   D_GREATER_EQUAL, D_LESS_EQUAL, D_DOT,     // >= <= ..
-  D_PLUS_EQUAL, D_STAR_EQUAL, D_SLASH_EQUAL,// += *= /=
-  D_MODULO_EQUAL, D_DOT_EQUAL, D_DIAMOND,   // %= .=
+  D_PLUS_EQUAL, D_STAR_EQUAL, D_DOT_EQUAL,  // += *= .=
+  D_MODULO_EQUAL, D_SLASH_EQUAL,            // %= /= 
+  //D_DIAMOND, // <>
   // Literals
   L_IDENTIFIER, L_STRING, L_NUMBER, 
   L_VARIABLE, // L_ARRAY,     // TODO implement array
+  
   // Keywords
-  TOKEN_PRINT, 
-
-  K_AND, K_AS,
-  K_DEFINE, K_DO,
-  K_ELSE,
-  K_FALSE,
-  K_IF, K_IS,
+  K_AND, K_AS, K_IF, K_UNLESS, K_ELSE, // 5
+  K_WHEN, K_IS, K_OR, K_RETURN, K_USE, // 10
+  K_WHILE, K_TRUE, K_UNTIL, K_FALSE, K_NULL, // 15
   K_LET,
+  // currently not used
+  K_DEFINE, K_DO, 
+  // may be removed in future
+  TOKEN_PRINT, 
+  // need to implement
   K_LIKE, // pattern matching
-  K_NULL,
-  K_OR,
-  K_RETURN,
-  K_UNLESS, K_UNTIL, K_USE,
-  K_WHEN, K_WHILE,
-  K_TRUE, K_TO,
+  K_TO,
   K_QUIT,
   // NEW_LINE, // TODO test
   LANGUAGE_ERROR, END_OF_FILE
@@ -53,6 +51,5 @@ typedef struct {
 
 void initScanner(const char* source);
 Token scanToken();
-
 
 #endif

--- a/vm.h
+++ b/vm.h
@@ -5,7 +5,7 @@
 #include "table.h"  // Hash Tables vm-include-table
 #include "value.h"  // vm-include-value
 
-#define FRAMES_MAX 64
+#define FRAMES_MAX 128
 #define STACK_MAX (FRAMES_MAX * UINT8_COUNT)
 // Calls and Functions frame-max
 
@@ -16,15 +16,15 @@ typedef struct {
 } CallFrame;
 
 typedef struct {
-// Array Calls and Functions
   CallFrame frames[FRAMES_MAX];
-  int frameCount; 
-// VM Stack
+  int frameCount;
+//^ Array Calls and Functions
   Value stack[STACK_MAX];
   Value* stackTop;
-// VM Tables
+//^ VM Stack
   Table globals; // Constants
   Table strings; // Strings
+//^ VM Tables
   ObjString* initString; // Methods and Initializers
   ObjUpvalue* openUpvalues; // Closures 
 
@@ -50,7 +50,6 @@ extern VM vm; // Strings extern-vm
 
 void initVM();
 void freeVM();
-
 InterpretResult interpret(const char* source);
 void push(Value value);
 Value pop();


### PR DESCRIPTION
To resolve bugs with stack allocated strings, mutables are now allowed in the Global table.

Had to refactor compound operators, added compiler checks for mutables called from functions, added compiler checks to stop mutables from being contained in a closure.