### PR TITLE
breaking change : 'let' removed

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -81,6 +81,10 @@ void advance() {
   }
 }
 
+void shorten() {
+  parser.previous = parser.caboose;
+}
+
 bool tokenIs(Lexeme test) {        
   return parser.head.lexeme == test;
 }
@@ -111,7 +115,7 @@ void synchronize() {
       return;
     } 
     switch (currentLexeme) {
-      case K_LET:
+      case K_AS:
       case K_IF:
       case K_UNLESS:
       case K_WHEN:

--- a/parser.h
+++ b/parser.h
@@ -51,6 +51,7 @@ void errorAt(Token* token, const char* message);
 void error(const char* message);
 void errorAtCurrent(const char* message);
 void advance();
+void shorten(); // EXPERIMENTAL
 bool tokenIs(Lexeme test);
 bool tokenIsNot(Lexeme test);
 bool previousIsNot(Lexeme test);

--- a/scanner.c
+++ b/scanner.c
@@ -141,8 +141,15 @@ static Lexeme identifierType() { // tests for keywords
         }
       }
       break;
-    case 'l': return checkKeyword(1, 2, "et", K_LET);
-    case 'n': return checkKeyword(1, 3, "ull", K_NULL); // because JSON uses 'null'
+    case 'l': return checkKeyword(1, 3, "ike", K_LIKE);
+    case 'n': 
+      if (scanner.current - scanner.start > 1) {
+        switch (scanner.start[1]) {
+          case 'o': return checkKeyword(2, 1, "t", K_NOT);
+          case 'u': return checkKeyword(2, 2, "ll", K_NULL);
+        }
+      }
+      break;
     case 'o': return checkKeyword(1, 1, "r", K_OR);
     case 'p': return checkKeyword(1, 4, "rint", TOKEN_PRINT); // TODO replace with native function
     case 'r': return checkKeyword(1, 5, "eturn", K_RETURN);
@@ -223,9 +230,10 @@ Token scanToken() {
     // single character
     case '#': return identifier();
     case '(': return makeToken(SL_ROUND, VT_VOID); // TODO would be new line aware
-    case ')': return makeToken(SR_ROUND, VT_VOID);
-    case '{': return makeToken(SL_CURLY, VT_VOID);   // TODO would be new line aware
+    case '{': return makeToken(SL_CURLY, VT_KEYED_COLLECTION);   // TODO would be new line aware
     case '}': return makeToken(SR_CURLY, VT_VOID);
+    case '[': return makeToken(SL_SQUARE, VT_INDEX_COLLECTION);
+    case ']': return makeToken(SR_SQUARE, VT_VOID);
     case '?': return makeToken(S_QUESTION, VT_VOID);     // TODO would be new line aware
     case ';': return makeToken(S_SEMICOLON, VT_VOID);
     case '=': return makeToken(S_EQUAL, VT_VOID); 
@@ -253,6 +261,8 @@ Token scanToken() {
           return makeToken(S_STAR, VT_VOID);
       }
       break;
+    case ')': 
+      return makeToken(match('*') ? D_STAR_R_ROUND : SR_ROUND, VT_VOID);
     case ',': 
       return makeToken(match(',') ? D_COMMA : S_COMMA, VT_VOID);
     case '%': 

--- a/scanner.h
+++ b/scanner.h
@@ -15,20 +15,31 @@ typedef enum {
   D_GREATER_EQUAL, D_MODULO_EQUAL, D_DOT,   // >= %= ..
   D_PLUS_EQUAL, D_STAR_EQUAL, D_DOT_EQUAL,  // += *= .=
   D_LESS_EQUAL, D_SLASH_EQUAL, D_STAR_L_ROUND,  // <= /= *( 
+  D_STAR_R_ROUND,
 
   // Literals
   L_IDENTIFIER, L_MUTABLE, L_STRING, L_NUMBER, 
-   // L_ARRAY,     // TODO implement array
+  // L_ARRAY,     // TODO implement array
   
   // Keywords
-  K_AND, K_AS, K_IF, K_UNLESS, K_ELSE,       //  5
-  K_WHEN, K_IS, K_OR, K_RETURN, K_USE,       // 10
-  K_WHILE, K_TRUE, K_UNTIL, K_FALSE, K_NULL, // 15
-  K_LET, K_QUIT,
+  K_AND, K_AS, 
+  K_ELSE,       
+  K_FALSE, 
+  // K_FROM,
+  // K_GIVE,
+  // K_HAS,
+  K_IF, K_IS,
+  K_NULL,
+  K_OR,
+  K_QUIT,
+  K_RETURN,
+  K_TRUE, 
+  K_WHEN, K_WHILE, 
+  K_UNLESS, K_UNTIL, K_USE,   // 16 active     
   // currently experimental
-  K_DEFINE, TOKEN_PRINT, 
-  K_LIKE, K_TO,
-  // NEW_LINE, // TODO test
+  K_DEFINE, TOKEN_PRINT, K_NOT,
+  K_TO, K_LIKE,
+  // NEW_LINE,
   LANGUAGE_ERROR, END_OF_FILE
 } Lexeme;
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,0 +1,320 @@
+## Comments, Colons, Question Marks, ';' and ',,'
+* For single line comments, Mu uses **( // )**.
+* Mu is designed to look closer to human writing, as such the colon '**:**' is not an operator. Colons are used with keywords to clarify boundaries, in contexts where the meaning is clearly defined.
+* For example the 'let' keyword is used to declare a variable, and is written **( let )** identifier **( : )** value **( ; )**.
+* The question mark **( ? )** is used to denote a guard-clause protected by a boolean condition. In other programming languages this would be represented with a 'then' keyword.
+* Semicolons **( ; )** are used to notate the end of a statement or expression, similar to most C inspired languages.
+* The double-comma **( ,, )** is used to notate the ending of a block of code. Blocks of code contain multiple statements or expressions.
+* Certain keywords **( while, until, if, unless, when, use )** always have an associated block of code.
+
+## Variable Declarations and Comments
+* There are two types of variables to declare: constants (which are immutable) and mutables. Both are initialized with the value or expression after the a **( : )** character.
+* Mutables can be reassigned with the **( := )** operator and Identifiers for mutables must begin with **( # )**, such as **#value** or **#name**.
+
+```
+let phrase : “Hello World”;   // constant
+
+let #number : 0;             // mutable
+#number  := 1;               // reassignment operator
+ 
+```
+## Arithmetic and Concatenation
+* For arithmetic operators Mu uses **( +, -, /, * )** and for concatenation **( .. )** is used.
+* Note: concatenation works with strings and strings or numbers and numbers.
+* Lastly, if one of the operands for number concatenation is negative, the runtime errors.
+```
+// addition
+let sum : 3 + 8;
+
+// subtraction
+let net : proft - cost;
+
+// multiplication
+let product : x * y;
+
+// division
+let quotient : x / y;
+
+// concatenation
+let phrase : "Hello" .. " " .. "World";
+print phrase;
+
+let number : 2 .. 1;
+print number;
+```
+```
+// "Hello World"
+// 21
+```
+## Logical Operators
+Mu uses the keywords **( and, or )** and the characters **( =, <, >, !~, <=, >=, ! )** for logical operators. 
+```
+1 and 2;   3 or 5;
+
+3 = 3;     1 !~ 2;
+3 > 5;    -7 >= 2;
+5 < 9;     3 <= 7;	    
+
+!(3 > 2)   // not (3 is greater than 2)
+
+```
+## Bitwise Operators
+Mu uses standard operators for bitwise and, or, xor, and not. **( &, |, ^, ~ )**. In the future Mu will support bit shifting left or right, but the implementation is still being thought out.
+```
+print 60 & 13;
+
+print 60 ^ 13;
+
+print 60 | 13;
+
+print ~60;
+```
+```
+//  12
+//  41
+//  61
+// -61
+```
+
+## Mutable Assignment Operators
+Mutables have short-hand operators to perform mutations. They are similar to other programming languages: sum assignment **(+=)**, product assignment **(*=)**, quotient assignment **(/=)**, concatenation assignment **(.=)**, and modulus assignment **(%=)**.
+```
+let #value : 34;
+let #textString : “Meoow, ”;
+
+// assign the sum of one plus the value
+#value += 1; 	 
+print #value;
+
+// assign the sum of negative five and the value
+#value += -5;
+print #value;
+
+// multiply the value by ten
+#value *= 10;  
+print #value;	 
+
+// divide the value by three
+#value /= 3;	  
+print #value;	 
+
+// assigns the remainder of the value from modulus five
+#value %= 5;	  
+
+// concatenate #textString
+#textString .= “meow.”; 
+print #textString;      
+```
+```
+// 35
+// 30
+// 300
+// 100
+// “Meoow, meow.”
+```
+## Logical Control Flow
+Mu has ternary statements **if-else**, **unless-else**. Based on a condition they act as a guard clause for one or two outcomes. Both **if** and **unless** can guard a single block of conditional code. 
+Note that else-if chaining is not possible in Mu. If a context is needed where one of several statements is true, Mu has a “when” statement. Shown further below. 
+
+```
+if 0 > 10 ?
+    print "yes zero is greater than ten";
+else 
+    print "no, zero is not greater than ten";
+,,
+
+
+let x: 5;
+unless x = 4 ?
+    print "good"; 
+else    
+    print "not good";
+,,
+
+
+unless x = 5 ?
+    print "it's not five"; 
+else
+    print "it is five";
+,,
+
+
+if (0 > -5) ?     
+    print "yes, zero is greater than negative five"; 
+,,
+```
+```
+// "no, zero is not greater than ten”
+// “good”
+// "it is five"
+// "yes, zero is greater than negative five"
+```
+The **when** statement is similar to switch in C-like languages: it allows for multiple branching outcomes. A key difference is that the when statement can check for any relational pattern ( =, >, <, !~, etc. ). Lastly, the **when** statement is break-by-default.
+```
+let value : 1;
+
+when value:
+    is = 0 ? print "it's zero";
+    ,,
+    is = 1 ? print "it's one";
+    ,, 
+    is >= 1 ? print "it's greater than or equal to one.";
+    ,,
+,,
+
+```
+```
+// “it’s one”
+```
+Loops are controlled by **while** or **until** statements. **While** is the standard loop that will break when the condition is false. **Until** is the same operations except the loop will break if true. This is to allow programmers to think with the booleans they have available and not worry about inverting. A programmer is free to write "until queue.isEmpty()" or "until stack.size() > 100". 
+```
+let #count : 1;
+
+while #count < 100 ?
+    print #count;
+    #count *= 2; 
+,,
+
+
+#count := 1;
+
+until #count > 100 ?
+    print #count;
+    #count *= 3;
+,,
+
+```
+```
+// 1 2 4 8 16 32 64
+// 1 3 9 27 81
+```
+(Not in alpha version 0.0.1) you can scope variables to loops in Mu. By adding a comma after **while** or **until** you can add a single declaration. The variable can be referred to as 'is' in the loop condition, or by its name.
+```
+while, #iteration : 0; is < 5 ?
+    print #iteration;
+    #iteration += 1;
+,,
+
+until, #u : 1; is > 35 ?
+    print #u;
+    #u *= 2;
+,,
+
+print #iteration;
+```
+```
+// 0 1 2 3 4
+// 1 2 4 8 16 32
+// Error: Undefined variable '#iteration'.
+```
+(Not in alpha version 0.0.1) you can scope two variables to a loop. However, they cannot be aliased with 'is'. This is to make writing two-pointer situations more consistent. 
+```
+until, #left : 4, #right : 20; 
+    #left >= #right ?
+
+    print #right + #left;
+    #right += -1;
+    #left += 1;
+,,
+
+while, #index : 0, arraySize : 10;
+    #index < arraySize ?
+    print #index;
+    #index += 1;
+,,
+```
+## Functions
+Mu represents functions with ( **use** ) expressions. The are anonymous and first-class. Following the grammars 'use' parameters* 'as' expression. The 'as' keyword can be omitted if the function simply returns an expression. **Use** expressions must have at least one input parameter.
+Functions can access constants from the global scope or within their closure, but they cannot access mutables outside of their scope.
+Function parameters can be constant or immutable, a function can be passed in a constant and have a mutable copy of the value.
+```
+let fibonacci: use n as
+    if n < 2 ? return n;
+    ,,
+    return fibonacci(n - 2) + fibonacci(n - 1);
+,,
+
+print fibonacci(20);
+
+let addTogether:
+    use x, y return x + y;
+,,
+print addTogether(22, 55);
+
+let multiplyBoth:
+    use x, y return x * y;
+,,
+print multiplyBoth(10, 99);
+
+let divideByTen:
+    use x return x / 10;
+,,
+print divideByTen(39);
+
+let isEven: 
+    use x return 0 = x % 2;
+,,
+
+print isEven(3);
+print isEven(58);
+```
+An example of function currying.
+```
+let defineAdd: 
+    use x return use y as
+        print x + y;
+        return x + y;
+    ,,
+,,
+
+let add5plus : defineAdd(5); 
+
+add5plus(3);   // 8
+add5plus(1);   // 6
+add5plus(2);   // 7
+```
+An example with mutable Function Parameters
+```
+let test : use x, #y as
+    #y *= #y;
+    return x + #y;
+,,
+print test(1, 2);
+```
+```
+// 5
+```
+## Function Closures and Global Scope
+Functions only being able to get constants from the global scope or their closure is a design choice to reduce side effects. If a mutable is to be used with a function, it has to be passed in as a parameter or declared within the function's scope.
+```
+//  ** Functions are not aware of mutables outside of their scope **
+//      let #number : 6;
+//      
+//      let increaseNumber: use input as
+//          #number := #number + input; // function doesn't know what #number is
+//          print #number;
+//      ,,
+//      increaseNumber(5); // won't work
+//  ** They are aware of constants, and can capture constants within a closure **
+
+let number : 6;
+let increaseNumberBy:
+    use x return number + x;
+,,
+
+print increaseNumberBy(3);  // 9
+print increaseNumberBy(2);  // 8
+print increaseNumberBy(1);  // 7
+print increaseNumberBy(0);  // 6
+print increaseNumberBy(-1); // 5
+
+let magicNumber : 12;
+
+let triplePlusValue : use y as
+  let #z : y;
+  #z *= 3;
+  return #z + magicNumber; 
+,,
+print triplePlusValue(9);
+
+```

--- a/vm.c
+++ b/vm.c
@@ -380,7 +380,7 @@ static InterpretResult run() {
         } else if (IS_NUMBER(peek(0)) && IS_NUMBER(peek(1))) {
           APPEND_INTEGER(NUMBER_VAL, +);
         } else {
-          runtimeError("Operands must be two strings, Or to integers.");
+          runtimeError("Operands must be two strings, Or two integers.");
           return INTERPRET_RUNTIME_ERROR;
         }
       }


### PR DESCRIPTION
Removed 'let' and replaced with 'as'

// as x : 22;

the '.' is now used in function notation, also allows for more consistent function notation

// use x . return x + 2;